### PR TITLE
Removed "beregningsid" from /minsteinntekt and /dagpengegrunnlag resp…

### DIFF
--- a/spec/components/schemas/DagpengegrunnlagBeregning.yaml
+++ b/spec/components/schemas/DagpengegrunnlagBeregning.yaml
@@ -1,5 +1,5 @@
 allOf:
-  - $ref: '#/components/schemas/Subsumsjon'
+  - $ref: '#/components/schemas/GrunnlagOgSatsSubsumsjon'
   - type: object
     required:
       - parametere

--- a/spec/components/schemas/GrunnlagOgSatsSubsumsjon.yaml
+++ b/spec/components/schemas/GrunnlagOgSatsSubsumsjon.yaml
@@ -1,0 +1,22 @@
+type: object
+required:
+  - satsSubsumsjonsId
+  - opprettet
+  - utfort
+properties:
+  grunnlagSubsumsjonsId:
+    type: string
+    example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+    description: Unik ID for denne beregningen
+  satsSubsumsjonsId:
+    type: string
+    example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+    description: Unik ID for denne beregningen
+  opprettet:
+    type: string
+    description: Dato for når kjøringen ble opprettet
+    example: '2018-12-26T14:42:09Z'
+  utfort:
+    type: string
+    description: Dato for når kjøringen ble oppdatert
+    example: '2018-12-26T14:43:12Z'

--- a/spec/components/schemas/MinsteinntektBeregning.yaml
+++ b/spec/components/schemas/MinsteinntektBeregning.yaml
@@ -1,5 +1,5 @@
 allOf:
-  - $ref: '#/components/schemas/Subsumsjon'
+  - $ref: '#/components/schemas/MinsteinntektOgPeriodeSubsumsjon'
   - type: object
     required:
       - parametere

--- a/spec/components/schemas/MinsteinntektOgPeriodeSubsumsjon.yaml
+++ b/spec/components/schemas/MinsteinntektOgPeriodeSubsumsjon.yaml
@@ -1,13 +1,17 @@
 type: object
 required:
-  - beregningsId
+  - minsteinntektSubsumsjonsId
   - opprettet
   - utfort
 properties:
-  beregningsId:
+  minsteinntektSubsumsjonsId:
     type: string
     example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
-    description: Unik ID for denne beregningen
+    description: Unik ID for minsteinntektberegning
+  periodeSubsumsjonsId:
+    type: string
+    example: 01ARZ3NDEKTSV4RRFFQ69G5FAV
+    description: Unik ID for periodeberegning
   opprettet:
     type: string
     description: Dato for når kjøringen ble opprettet

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/arena/adapter/v1/minsteinntekt_periode/MinsteinntektOgPeriodeSubsumsjon.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/arena/adapter/v1/minsteinntekt_periode/MinsteinntektOgPeriodeSubsumsjon.kt
@@ -12,7 +12,7 @@ import java.time.LocalDateTime
 
 data class MinsteinntektOgPeriodeSubsumsjon(
     val minsteinntektSubsumsjonsId: String,
-    val periodeSubsumsjonsId: String,
+    val periodeSubsumsjonsId: String? = null,
     val opprettet: LocalDateTime, // todo: ZonedDateTime?
     val utfort: LocalDateTime, // todo: ZonedDateTime?,
     val parametere: MinsteinntektOgPeriodeRegelfaktum,


### PR DESCRIPTION
…onses,

 replaced by 'minsteinntektSubsumsjonsId' and 'periodeSubsumsjonsId' for /minsteinntekt
 and 'satsSubsumsjonsId' and 'grunnlagSubsumsjonsId'

- 'periodeSubsumsjonsId' is not required in the response.