### PR TITLE
Add documentation for security schemes in API.

### DIFF
--- a/spec/components/securitySchemes/stsOIDC.yaml
+++ b/spec/components/securitySchemes/stsOIDC.yaml
@@ -1,0 +1,3 @@
+type: openIdConnect
+openIdConnectUrl: >-
+  https://security-token-service.nais.preprod.local/rest/v1/sts/.well-known/openid-configuration

--- a/spec/components/securitySchemes/stsTokenAuth.yaml
+++ b/spec/components/securitySchemes/stsTokenAuth.yaml
@@ -1,0 +1,13 @@
+type: http
+scheme: bearer
+bearerFormat: JWT
+description: |
+  Lag OIDC tokens med STS:
+  * Prod: <https://security-token-service.nais.adeo.no/>
+  * Test: <https://security-token-service.nais.preprod.local/>
+
+  Triks for å lage token i CLI: 
+
+      DP_TOKEN=$(curl -v --user <SystemBRUKER>:<Passord> \
+        https://security-token-service.nais.preprod.local/rest/v1/sts/token/\?grant_type\=client_credentials\&scope\=openid \
+        | jq -r .access_token)

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -3,13 +3,10 @@ info:
   title: Dagpenger Regel API - Arena Adapter
   version: '1.0'
 servers:
-  - url: 'https://dagpenger-regel-api-arena-adapter.nais.adeo.no:{port}/v1'
-    variables:
-      port:
-        default: '443'
-        enum:
-          - '443'
-          - '8443'
+  - url: 'https://dagpenger-regel-api-arena-adapter.nais.adeo.no/v1'
+    description: Produksjon (bruker ekte data)
+  - url: 'https://dagpenger-regel-api-arena-adapter.nais.preprod.local/v1'
+    description: Test (bruker test data)
 tags:
   - name: Minsteinntekt
     description: Beregner minsteinntekt og dagpengeperiode etter §4-4 og §4-15
@@ -25,3 +22,7 @@ tags:
     description: >-
       Operasjon for å vurdere om inntektene fremdeles er gyldige for gitt
       beregningsdatoen.
+security:
+  - stsTokenAuth: []
+  - stsOIDC:
+      - openid


### PR DESCRIPTION
Automatic OIDC is not yet supported in Swagger UI, so it also contains a more manual approach to creating the OIDC token.