### PR TITLE
Remove runBlocking when fetching "subsumsjon"-status.

### DIFF
--- a/src/main/kotlin/no/nav/dagpenger/regel/api/internal/SynchronousSubsumsjonClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/internal/SynchronousSubsumsjonClient.kt
@@ -1,6 +1,5 @@
 package no.nav.dagpenger.regel.api.internal
 
-import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.regel.api.arena.adapter.v1.SubsumsjonProblem
 import no.nav.dagpenger.regel.api.internal.models.Subsumsjon
 import java.time.LocalDateTime
@@ -11,7 +10,7 @@ class SynchronousSubsumsjonClient(
     private val subsumsjonHttpClient: RegelApiSubsumsjonHttpClient
 ) {
 
-    fun <T> getSubsumsjonSynchronously(
+    suspend fun <T> getSubsumsjonSynchronously(
         behovRequest: BehovRequest,
         extractResult: (subsumsjon: Subsumsjon, opprettet: LocalDateTime, utfort: LocalDateTime) -> T
     ): T {
@@ -19,7 +18,7 @@ class SynchronousSubsumsjonClient(
         val opprettet = LocalDateTime.now()
 
         val statusUrl = behovHttpClient.run(behovRequest)
-        val subsumsjonLocation = runBlocking { statusHttpClient.pollStatus(statusUrl) }
+        val subsumsjonLocation = statusHttpClient.pollStatus(statusUrl)
         val subsumsjon = subsumsjonHttpClient.getSubsumsjon(subsumsjonLocation)
 
         val utfort = LocalDateTime.now()

--- a/src/test/kotlin/no/nav/dagpenger/regel/api/arena/adapter/v1/GrunnlagOgSatsApiTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/api/arena/adapter/v1/GrunnlagOgSatsApiTest.kt
@@ -9,6 +9,7 @@ import io.ktor.server.testing.setBody
 import io.ktor.server.testing.withTestApplication
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
 import no.nav.dagpenger.regel.api.JwtStub
 import no.nav.dagpenger.regel.api.arena.adapter.Problem
 import no.nav.dagpenger.regel.api.arena.adapter.mockedRegelApiAdapter
@@ -74,9 +75,12 @@ class GrunnlagOgSatsApiTest {
         val synchronousSubsumsjonClient: SynchronousSubsumsjonClient = mockk()
 
         every {
-            synchronousSubsumsjonClient.getSubsumsjonSynchronously(
-                any(),
-                any<(Subsumsjon, LocalDateTime, LocalDateTime) -> GrunnlagOgSatsSubsumsjon>())
+            runBlocking {
+                synchronousSubsumsjonClient.getSubsumsjonSynchronously(
+                    any(),
+                    any<(Subsumsjon, LocalDateTime, LocalDateTime) -> GrunnlagOgSatsSubsumsjon>()
+                )
+            }
         } returns grunnlagOgSatsSubsumsjon()
 
         withTestApplication({
@@ -105,7 +109,8 @@ class GrunnlagOgSatsApiTest {
                     expectedJson, response.content,
                     CustomComparator(JSONCompareMode.LENIENT,
                         Customization("opprettet") { _, _ -> true },
-                        Customization("utfort") { _, _ -> true }))
+                        Customization("utfort") { _, _ -> true })
+                )
             }
         }
     }
@@ -116,9 +121,12 @@ class GrunnlagOgSatsApiTest {
         val synchronousSubsumsjonClient: SynchronousSubsumsjonClient = mockk()
 
         every {
-            synchronousSubsumsjonClient.getSubsumsjonSynchronously(
-                any(),
-                any<(Subsumsjon, LocalDateTime, LocalDateTime) -> GrunnlagOgSatsSubsumsjon>())
+            runBlocking {
+                synchronousSubsumsjonClient.getSubsumsjonSynchronously(
+                    any(),
+                    any<(Subsumsjon, LocalDateTime, LocalDateTime) -> GrunnlagOgSatsSubsumsjon>()
+                )
+            }
         } throws RuntimeException()
 
         withTestApplication({
@@ -158,9 +166,12 @@ class GrunnlagOgSatsApiTest {
         val problem = Problem(title = "subsumsjon problem")
         val synchronousSubsumsjonClient = mockk<SynchronousSubsumsjonClient>().apply {
             every {
-                this@apply.getSubsumsjonSynchronously(
-                    any(),
-                    any<(Subsumsjon, LocalDateTime, LocalDateTime) -> GrunnlagOgSatsSubsumsjon>())
+                runBlocking {
+                    this@apply.getSubsumsjonSynchronously(
+                        any(),
+                        any<(Subsumsjon, LocalDateTime, LocalDateTime) -> GrunnlagOgSatsSubsumsjon>()
+                    )
+                }
             } throws SubsumsjonProblem(problem)
         }
 
@@ -200,9 +211,12 @@ class GrunnlagOgSatsApiTest {
         val synchronousSubsumsjonClient: SynchronousSubsumsjonClient = mockk()
 
         every {
-            synchronousSubsumsjonClient.getSubsumsjonSynchronously(
-                any(),
-                any<(Subsumsjon, LocalDateTime, LocalDateTime) -> GrunnlagOgSatsSubsumsjon>())
+            runBlocking {
+                synchronousSubsumsjonClient.getSubsumsjonSynchronously(
+                    any(),
+                    any<(Subsumsjon, LocalDateTime, LocalDateTime) -> GrunnlagOgSatsSubsumsjon>()
+                )
+            }
         } throws RegelApiTimeoutException("timeout")
 
         withTestApplication({
@@ -281,7 +295,10 @@ class GrunnlagOgSatsApiTest {
             }.apply {
                 assertEquals(HttpStatusCode.BadRequest, response.status())
                 val problem = moshiInstance.adapter<Problem>(Problem::class.java).fromJson(response.content!!)
-                assertEquals("Parameteret er ikke gyldig, mangler obligatorisk felt: 'Required value 'vedtakId' missing at \$'", problem?.title)
+                assertEquals(
+                    "Parameteret er ikke gyldig, mangler obligatorisk felt: 'Required value 'vedtakId' missing at \$'",
+                    problem?.title
+                )
                 assertEquals("urn:dp:error:parameter", problem?.type.toString())
                 assertEquals(400, problem?.status)
             }
@@ -346,15 +363,17 @@ class GrunnlagOgSatsApiTest {
                 benyttet90ProsentRegel = false
             ),
             inntekt =
-            setOf(no.nav.dagpenger.regel.api.arena.adapter.v1.models.Inntekt(
-                inntekt = 4999423,
-                inntektsPeriode = no.nav.dagpenger.regel.api.arena.adapter.v1.models.InntektsPeriode(
-                    foersteMaaned = YearMonth.of(2018, 1),
-                    sisteMaaned = YearMonth.of(2019, 1)
-                ),
-                inneholderNaeringsinntekter = false,
-                periode = 1
-            )),
+            setOf(
+                no.nav.dagpenger.regel.api.arena.adapter.v1.models.Inntekt(
+                    inntekt = 4999423,
+                    inntektsPeriode = no.nav.dagpenger.regel.api.arena.adapter.v1.models.InntektsPeriode(
+                        foersteMaaned = YearMonth.of(2018, 1),
+                        sisteMaaned = YearMonth.of(2019, 1)
+                    ),
+                    inneholderNaeringsinntekter = false,
+                    periode = 1
+                )
+            ),
             inntektManueltRedigert = true,
             inntektAvvik = true
         )

--- a/src/test/kotlin/no/nav/dagpenger/regel/api/internal/SynchronousSubsumsjonClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/api/internal/SynchronousSubsumsjonClientTest.kt
@@ -48,7 +48,7 @@ class SynchronousSubsumsjonClientTest {
 
         val testFunction = { subsumsjon: Subsumsjon, _: LocalDateTime, _: LocalDateTime -> subsumsjon.behovId }
 
-        val behovId = synchronousSubsumsjonClient.getSubsumsjonSynchronously(behovRequest, testFunction)
+        val behovId = runBlocking { synchronousSubsumsjonClient.getSubsumsjonSynchronously(behovRequest, testFunction) }
 
         assertEquals("565656", behovId)
     }
@@ -67,7 +67,13 @@ class SynchronousSubsumsjonClientTest {
         }
 
         shouldThrow<SubsumsjonProblem> {
-            SynchronousSubsumsjonClient(behovHttpClient, statusHttpClient, apply).getSubsumsjonSynchronously(mockk()) { subsumsjon, _, _ -> subsumsjon }
+            runBlocking {
+                SynchronousSubsumsjonClient(
+                    behovHttpClient,
+                    statusHttpClient,
+                    apply
+                ).getSubsumsjonSynchronously(mockk()) { subsumsjon, _, _ -> subsumsjon }
+            }
         }.apply {
             this.problem shouldBe problem
         }


### PR DESCRIPTION
runBlocking will
```
 Runs a new coroutine and **blocks** the current thread _interruptibly_ until its completion.
 This function should not be used from a coroutine. It is designed to bridge regular blocking code
 to libraries that are written in suspending style, to be used in `main` functions and in tests.
 ```
Specially ` This function should not be used from a coroutine.` - as ktor uses couroutines to serve requests
resolves navikt/dagpenger#162