### PR TITLE
Migrer til Jackson 3 (tools.jackson)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,8 @@ val jar by tasks.getting(Jar::class) {
 
 val prometheusVersion = "0.16.0"
 val kafkaVersion = "8.1.1-ce"
-val ktorVersion = "3.3.3"
+val ktorVersion = libs.versions.ktor.get()
+
 dependencies {
     implementation(kotlin("stdlib"))
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,11 +2,12 @@ rootProject.name = "dp-regel-api-arena-adapter"
 
 dependencyResolutionManagement {
     repositories {
+        mavenCentral()
         maven("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
     }
     versionCatalogs {
         create("libs") {
-            from("no.nav.dagpenger:dp-version-catalog:20251205.234.05353f")
+            from("no.nav.dagpenger:dp-version-catalog:20260728.277")
         }
     }
 }

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/arena/adapter/RegelApiArenaAdapter.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/arena/adapter/RegelApiArenaAdapter.kt
@@ -2,11 +2,10 @@ package no.nav.dagpenger.regel.api.arena.adapter
 
 import com.auth0.jwk.JwkProvider
 import com.auth0.jwk.JwkProviderBuilder
-import com.fasterxml.jackson.databind.JsonMappingException
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.serialization.jackson.JacksonConverter
+import io.ktor.serialization.jackson3.JacksonConverter
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.auth.Authentication
@@ -47,6 +46,7 @@ import no.nav.dagpenger.regel.api.internal.RegelApiMinsteinntektNyVurderingExcep
 import no.nav.dagpenger.regel.api.internal.RegelApiTimeoutException
 import no.nav.dagpenger.regel.api.serder.jacksonObjectMapper
 import org.slf4j.event.Level
+import tools.jackson.databind.DatabindException
 import java.net.URI
 import java.util.concurrent.TimeUnit
 
@@ -132,7 +132,7 @@ internal fun Application.regelApiAdapter(
                 )
             call.respond(HttpStatusCode.InternalServerError, problem)
         }
-        exception<JsonMappingException> { call, cause ->
+        exception<DatabindException> { call, cause ->
             LOGGER.warn(cause) { cause.message }
             val status = HttpStatusCode.BadRequest
             val problem =

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/internal/InntektApiInntjeningsperiodeHttpClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/internal/InntektApiInntjeningsperiodeHttpClient.kt
@@ -14,7 +14,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
-import io.ktor.serialization.jackson.JacksonConverter
+import io.ktor.serialization.jackson3.JacksonConverter
 import no.nav.dagpenger.regel.api.internal.models.InntjeningsperiodeParametre
 import no.nav.dagpenger.regel.api.internal.models.InntjeningsperiodeResultat
 import no.nav.dagpenger.regel.api.serder.jacksonObjectMapper

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/internal/RegelApiBehovHttpClient.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/internal/RegelApiBehovHttpClient.kt
@@ -18,7 +18,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
-import io.ktor.serialization.jackson.JacksonConverter
+import io.ktor.serialization.jackson3.JacksonConverter
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.time.delay
 import kotlinx.coroutines.withTimeout

--- a/src/main/kotlin/no/nav/dagpenger/regel/api/serder/ObjectMapper.kt
+++ b/src/main/kotlin/no/nav/dagpenger/regel/api/serder/ObjectMapper.kt
@@ -1,15 +1,14 @@
 package no.nav.dagpenger.regel.api.serder
 
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.module.kotlin.jacksonMapperBuilder
 
+// java.time support is built into jackson-databind in Jackson 3 — no JavaTimeModule registration needed
 internal val jacksonObjectMapper =
-    jacksonObjectMapper().also {
-        it.registerModule(JavaTimeModule())
-        it.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-        it.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-        it.setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
-    }
+    jacksonMapperBuilder()
+        // DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS now defaults to false — dates serialize as ISO-8601 strings already
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .changeDefaultPropertyInclusion { it.withValueInclusion(JsonInclude.Include.NON_NULL) }
+        .changeDefaultPropertyInclusion { it.withContentInclusion(JsonInclude.Include.NON_NULL) }
+        .build()

--- a/src/test/kotlin/no/nav/dagpenger/regel/api/internal/RegelApiBehovHttpClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/api/internal/RegelApiBehovHttpClientTest.kt
@@ -5,7 +5,7 @@ import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern
 import com.github.tomakehurst.wiremock.matching.EqualToPattern
-import io.kotest.engine.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll

--- a/src/test/kotlin/no/nav/dagpenger/regel/api/internal/RegelApiNyVurderingHttpClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/api/internal/RegelApiNyVurderingHttpClientTest.kt
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.matching.EqualToPattern
-import io.kotest.engine.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/no/nav/dagpenger/regel/api/internal/RegelApiSubsumsjonHttpClientTest.kt
+++ b/src/test/kotlin/no/nav/dagpenger/regel/api/internal/RegelApiSubsumsjonHttpClientTest.kt
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.matching.EqualToPattern
-import io.kotest.engine.runBlocking
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeAll


### PR DESCRIPTION
## Hva
Migrerer prosjektet fra Jackson 2 (com.fasterxml.jackson) til Jackson 3 (tools.jackson).

## Endringer
- `ObjectMapper.kt`: mutable `ObjectMapper().apply{}` → immutable `jacksonMapperBuilder()`. `JavaTimeModule` fjernet (innebygd i Jackson 3). `setDefaultPropertyInclusion` → `changeDefaultPropertyInclusion` (verdi + innhold).
- `RegelApiArenaAdapter.kt`: `JsonMappingException` → `tools.jackson.databind.DatabindException` (gammel import kompilerte stille mot en gjenværende Jackson 2.x-jar dratt inn transitivt via `nimbus-jose-jwt`/`ktor-server-auth-jwt`).
- 3 filer: `io.ktor.serialization.jackson.JacksonConverter` → `io.ktor.serialization.jackson3.JacksonConverter`.
- `build.gradle.kts`: fjernet hardkodet `ktorVersion = "3.3.3"` til fordel for `libs.versions.ktor.get()` — fjerner reell versjonsskjevhet der `ktor-server-netty`/`-call-logging`/`-default-headers` lå igjen på 3.3.3 mens resten av Ktor-stacken var på 3.5.1 fra katalogen.
- 3 testfiler: `io.kotest.engine.runBlocking` (finnes ikke) → `kotlinx.coroutines.runBlocking` (urelatert pre-eksisterende feil, oppdaget under verifisering).

## Verifisering
- Full `./gradlew build` (kompilering + testsuite) grønt lokalt.
- Kjent gap: `exception<DatabindException>`-handleren ser ut til å være ubrukt i praksis (Ktors ContentNegotiation pakker parse-feil i `BadRequestException` i stedet), men dette er pre-eksisterende adferd, ikke en regresjon.

## Merking
**Ikke merget ennå** — ønsker å teste med reell trafikk i arbeidstid før merge.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>